### PR TITLE
Refactor: Decouple path computation from processing time calculation

### DIFF
--- a/eclypse/placement/placement.py
+++ b/eclypse/placement/placement.py
@@ -114,7 +114,7 @@ class Placement:
 
                 path = self.infrastructure.path(caller_node, target)
 
-                if path and any(u == source and v == target for (u, v, _) in path[0]):
+                if path and any(u == source and v == target for (u, v, _) in path):
                     interactions.append((caller, callee))
 
         # interactions starting from services placed on source
@@ -126,7 +126,7 @@ class Placement:
                     continue  # skip local interactions
 
                 path = self.infrastructure.path(source, callee_node)
-                if path and any(u == source and v == target for (u, v, _) in path[0]):
+                if path and any(u == source and v == target for (u, v, _) in path):
                     interactions.append((caller, callee))
 
         return interactions

--- a/eclypse/placement/view.py
+++ b/eclypse/placement/view.py
@@ -167,7 +167,6 @@ class PlacementView(nx.DiGraph):
                 )
                 _path = placement.infrastructure.path(node_s, node_t)
                 if _path:
-                    path = _path[0]
                     _int_reqs = {
                         k: (
                             self.edge_assets[k].lower_bound
@@ -177,7 +176,7 @@ class PlacementView(nx.DiGraph):
                         for k in int_reqs
                     }
 
-                    for n1, n2, _ in path:
+                    for n1, n2, _ in _path:
                         new_int_reqs = self.edge_aggregate(
                             self.get_edge_view(n1, n2), _int_reqs
                         )

--- a/eclypse/simulation/_simulator/remote.py
+++ b/eclypse/simulation/_simulator/remote.py
@@ -114,20 +114,19 @@ class RemoteSimulator(Simulator):
         path = (
             self.infrastructure.path(source_node, dest_node)
             if source_node != dest_node
-            else ([], 0)
+            else []
         )
 
-        return (
-            None
-            if path is None
-            else Route(
-                sender_id=source_id,
-                sender_node_id=source_node,
-                recipient_id=dest_id,
-                recipient_node_id=dest_node,
-                processing_time=path[1],
-                hops=path[0],
-            )
+        if path is None:
+            return None
+
+        return Route(
+            sender_id=source_id,
+            sender_node_id=source_node,
+            recipient_id=dest_id,
+            recipient_node_id=dest_node,
+            processing_time=self.infrastructure.processing_time(source_node, dest_node),
+            hops=path,
         )
 
     async def get_neighbors(self, application_id: str, service_id: str) -> List[str]:


### PR DESCRIPTION
# Refactor: Decouple path computation from processing time calculation

## Description
Refactors the `Infrastructure` class to follow the single responsibility principle by separating path computation from processing time calculation.

## Changes
- **Split `path()` method**: Now returns only per-hop costs as `List[Tuple[str, str, Dict[str, Any]]]` instead of a tuple with processing time
- **New `processing_time()` method**: Dedicated method to calculate total processing time along a path
- **Removed caching**: Eliminated `_processing_times` cache which is no longer needed
- **Updated dependencies**: Modified all callers of `path()` across the codebase to use the new method signatures

## Motivation
The original `path()` method had two responsibilities: returning per-hop costs and computing total processing time. This refactor improves code clarity and maintainability by giving each method a single, well-defined purpose.


Signed-off-by: Niccolò Quadrani <niccoloquadrani13@gmail.com>